### PR TITLE
feat: add github_create_pr and github_compare_branches MCP tools

### DIFF
--- a/src/ghost/github_client.py
+++ b/src/ghost/github_client.py
@@ -746,6 +746,101 @@ class GitHubClient:
             "url": review.get("html_url"),
         }
 
+    def create_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        title: str,
+        head: str,
+        base: str = "main",
+        body: str | None = None,
+        draft: bool = False,
+        maintainer_can_modify: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Create a new pull request.
+
+        Args:
+            owner: Repository owner (user or organization)
+            repo: Repository name
+            title: PR title
+            head: The name of the branch where your changes are implemented.
+                  For cross-repository PRs use 'username:branch'.
+            base: The name of the branch you want the changes pulled into (default: 'main')
+            body: PR body/description (Markdown)
+            draft: Whether to create the PR as a draft
+            maintainer_can_modify: Whether maintainers can modify the PR
+
+        Returns:
+            Created pull request details
+        """
+        json_body: dict[str, Any] = {
+            "title": title,
+            "head": head,
+            "base": base,
+            "draft": draft,
+            "maintainer_can_modify": maintainer_can_modify,
+        }
+
+        if body:
+            json_body["body"] = body
+
+        pr = self._post(f"/repos/{owner}/{repo}/pulls", json_body=json_body)
+        return self._format_pr_detail(pr)
+
+    def compare_branches(
+        self,
+        owner: str,
+        repo: str,
+        base: str,
+        head: str,
+    ) -> dict[str, Any]:
+        """
+        Compare two branches/commits/tags.
+
+        Uses the GitHub Compare API: GET /repos/{owner}/{repo}/compare/{base}...{head}
+
+        Args:
+            owner: Repository owner
+            repo: Repository name
+            base: Base branch, tag, or commit SHA
+            head: Head branch, tag, or commit SHA
+
+        Returns:
+            Comparison details with status, commits, and files changed
+        """
+        result = self._get(f"/repos/{owner}/{repo}/compare/{base}...{head}")
+
+        return {
+            "status": result["status"],  # ahead, behind, diverged, identical
+            "ahead_by": result["ahead_by"],
+            "behind_by": result["behind_by"],
+            "total_commits": result["total_commits"],
+            "commits": [
+                {
+                    "sha": c["sha"][:8],
+                    "message": c["commit"]["message"].split("\n")[0],
+                    "author": c["commit"]["author"]["name"],
+                    "date": c["commit"]["author"]["date"],
+                    "url": c["html_url"],
+                }
+                for c in result.get("commits", [])
+            ],
+            "files": [
+                {
+                    "filename": f["filename"],
+                    "status": f["status"],
+                    "additions": f["additions"],
+                    "deletions": f["deletions"],
+                    "changes": f["changes"],
+                    "patch": f.get("patch"),
+                }
+                for f in result.get("files", [])
+            ],
+            "diff_url": result.get("diff_url"),
+            "html_url": result.get("html_url"),
+        }
+
     def search_pull_requests(
         self,
         query: str,

--- a/src/ghost/server.py
+++ b/src/ghost/server.py
@@ -36,6 +36,8 @@ from ghost.tools.schemas import (
     GetWeeklyActivityInput,
     # GitHub Pull Requests
     GitHubAddPRCommentInput,
+    GitHubCompareBranchesInput,
+    GitHubCreatePRInput,
     GitHubGetPRCommentsInput,
     GitHubGetPRCommitsInput,
     GitHubGetPRDiffInput,
@@ -887,6 +889,78 @@ GITHUB_TOOLS: list[Tool] = [
                 },
             },
             "required": ["query"],
+        },
+    ),
+    # --- GitHub PR Create & Compare ---
+    Tool(
+        name="github_create_pr",
+        description="Create a new pull request. Returns the created PR with its number, URL, and full details.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "owner": {
+                    "type": "string",
+                    "description": "Repository owner (user or organization).",
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "Repository name.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Pull request title.",
+                },
+                "head": {
+                    "type": "string",
+                    "description": "The name of the branch where your changes are implemented. For cross-repository PRs use 'username:branch'.",
+                },
+                "base": {
+                    "type": "string",
+                    "description": "The name of the branch you want the changes pulled into. Default: 'main'.",
+                    "default": "main",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Pull request body/description (Markdown).",
+                },
+                "draft": {
+                    "type": "boolean",
+                    "description": "Whether to create the pull request as a draft. Default: false.",
+                    "default": False,
+                },
+                "maintainer_can_modify": {
+                    "type": "boolean",
+                    "description": "Whether maintainers can modify the pull request. Default: true.",
+                    "default": True,
+                },
+            },
+            "required": ["owner", "repo", "title", "head"],
+        },
+    ),
+    Tool(
+        name="github_compare_branches",
+        description="Compare two branches, tags, or commits. Returns the comparison status (ahead/behind/diverged), list of commits, and files changed. Useful for understanding what changes exist between two refs before creating a PR.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "owner": {
+                    "type": "string",
+                    "description": "Repository owner (user or organization).",
+                },
+                "repo": {
+                    "type": "string",
+                    "description": "Repository name.",
+                },
+                "base": {
+                    "type": "string",
+                    "description": "Base branch, tag, or commit SHA.",
+                },
+                "head": {
+                    "type": "string",
+                    "description": "Head branch, tag, or commit SHA.",
+                },
+            },
+            "required": ["owner", "repo", "base", "head"],
         },
     ),
     Tool(
@@ -2218,6 +2292,30 @@ async def _execute_github_tool(
 
     elif name == "github_get_current_user":
         return github_client.get_current_user()
+
+    # --- GitHub PR Create & Compare ---
+
+    elif name == "github_create_pr":
+        input_data = GitHubCreatePRInput(**arguments)
+        return github_client.create_pull_request(
+            owner=input_data.owner,
+            repo=input_data.repo,
+            title=input_data.title,
+            head=input_data.head,
+            base=input_data.base,
+            body=input_data.body,
+            draft=input_data.draft,
+            maintainer_can_modify=input_data.maintainer_can_modify,
+        )
+
+    elif name == "github_compare_branches":
+        input_data = GitHubCompareBranchesInput(**arguments)
+        return github_client.compare_branches(
+            owner=input_data.owner,
+            repo=input_data.repo,
+            base=input_data.base,
+            head=input_data.head,
+        )
 
     # --- GitHub PR Review Tools ---
 

--- a/src/ghost/tools/schemas.py
+++ b/src/ghost/tools/schemas.py
@@ -833,6 +833,66 @@ class GitHubSearchPRsInput(BaseModel):
     )
 
 
+class GitHubCreatePRInput(BaseModel):
+    """Input schema for github_create_pr tool."""
+
+    owner: str = Field(
+        ...,
+        description="Repository owner (user or organization).",
+    )
+    repo: str = Field(
+        ...,
+        description="Repository name.",
+    )
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=256,
+        description="Pull request title.",
+    )
+    head: str = Field(
+        ...,
+        description="The name of the branch where your changes are implemented. For cross-repository PRs use 'username:branch'.",
+    )
+    base: str = Field(
+        default="main",
+        description="The name of the branch you want the changes pulled into. Default: 'main'.",
+    )
+    body: str | None = Field(
+        default=None,
+        description="Pull request body/description (Markdown).",
+    )
+    draft: bool = Field(
+        default=False,
+        description="Whether to create the pull request as a draft. Default: false.",
+    )
+    maintainer_can_modify: bool = Field(
+        default=True,
+        description="Whether maintainers can modify the pull request. Default: true.",
+    )
+
+
+class GitHubCompareBranchesInput(BaseModel):
+    """Input schema for github_compare_branches tool."""
+
+    owner: str = Field(
+        ...,
+        description="Repository owner (user or organization).",
+    )
+    repo: str = Field(
+        ...,
+        description="Repository name.",
+    )
+    base: str = Field(
+        ...,
+        description="Base branch, tag, or commit SHA.",
+    )
+    head: str = Field(
+        ...,
+        description="Head branch, tag, or commit SHA.",
+    )
+
+
 # --- GitHub PR Review Input Schemas ---
 
 


### PR DESCRIPTION
## Summary

- Add `github_create_pr` tool to enable creating pull requests directly via MCP
- Add `github_compare_branches` tool to compare two branches/tags/commits and return status, commits, and changed files
- Eliminates the need to fall back to the `gh` CLI for PR creation and branch comparison workflows

## Changes

- `src/ghost/github_client.py` — Added `create_pull_request()` and `compare_branches()` methods
- `src/ghost/server.py` — Added Tool definitions, schema imports, and handler branches
- `src/ghost/tools/schemas.py` — Added `GitHubCreatePRInput` and `GitHubCompareBranchesInput` Pydantic models